### PR TITLE
Add syslog_forwarder job

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,128 +1,128 @@
 cerebro/cerebro-0.8.5.tgz:
   size: 52409310
-  object_id: 1ebc64b1-4f12-460f-43d4-42824b712cae
+  object_id: 9901885a-b222-4d33-769c-5de9048b62fe
   sha: sha256:97cdba6c0054f505c6ac72ca5ae010612c86385ac0f7f760cf512e5705a00a27
 curator/elasticsearch-curator-v5.7.6.tar.gz:
   size: 223849
-  object_id: 59bb52d9-c633-415b-7481-ee6d1e5ac070
+  object_id: 5bc54ecf-cb6d-4252-5542-ae0f1e889554
   sha: sha256:a48486cacf0b32038358babfc5a8755c9a24992ff5279226b923298b426fe253
 curator/vendor/PyYAML-3.12.zip:
   size: 375811
-  object_id: 953d3785-a6ac-4cf0-5fed-2448d6c9cfd8
+  object_id: 6bab6751-63a5-49bf-4d11-3959e99260e0
   sha: sha256:5ac82e411044fb129bae5cfbeb3ba626acb2af31a8d17d175004b70862a741a7
 curator/vendor/boto3-1.12.36-py2.py3-none-any.whl:
   size: 128570
-  object_id: af0283d3-0663-4e0f-4f76-60c2b8e14a43
+  object_id: e22ca6d6-3339-4360-6b73-dbafc44e5658
   sha: sha256:57397f9ad3e9afc17e6100a38c6e631b6545aabc7f8c38b86ff2c6f5931d0ebf
 curator/vendor/botocore-1.15.36-py2.py3-none-any.whl:
   size: 6066108
-  object_id: a4769647-1978-4656-7c17-328265413809
+  object_id: d7278e18-38c6-42ee-4e3a-f8a4f82f9ecd
   sha: sha256:d2233e19b6a60792185b15fe4cd8f92c5579298e5079daf17f66f6e639585e3a
 curator/vendor/click-6.7-py2.py3-none-any.whl:
   size: 71175
-  object_id: 0e7bc065-2792-4ad2-7d22-382a4be1b814
+  object_id: b2befa12-45f4-4311-4fc5-f617e45f3c59
   sha: sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d
 curator/vendor/docutils-0.15.2-py3-none-any.whl:
   size: 547604
-  object_id: 444ff506-2869-43ce-6352-6773811f560c
+  object_id: 59ee43e2-4d79-4cfc-5a0b-424e669b6a68
   sha: sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0
 curator/vendor/elasticsearch-7.6.0-py2.py3-none-any.whl:
   size: 88688
-  object_id: c0bb115e-076f-44f1-781c-d598498158d2
+  object_id: 1d72fdf7-9a61-4211-482d-ed35f55f86e8
   sha: sha256:f4bb05cfe55cf369bdcb4d86d0129d39d66a91fd9517b13cd4e4231fbfcf5c81
 curator/vendor/jmespath-0.9.5-py2.py3-none-any.whl:
   size: 24149
-  object_id: 783dc8c3-084d-4ce8-6cf3-3297ef2f12c4
+  object_id: 4cd63aac-726b-475c-7bdc-68d4da5f5b70
   sha: sha256:695cb76fa78a10663425d5b73ddc5714eb711157e52704d69be03b1a02ba4fec
 curator/vendor/python_dateutil-2.8.1-py2.py3-none-any.whl:
   size: 227183
-  object_id: 16589862-e597-4874-7905-c9a429f30561
+  object_id: a0da919d-2599-410c-6513-9cfdae7aed27
   sha: sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a
 curator/vendor/requests_aws4auth-0.9-py2.py3-none-any.whl:
   size: 54238
-  object_id: cf4ddb90-53c9-4f88-4441-4929ff008a92
+  object_id: 28ea1d6f-f180-485f-7a52-64e43ab5d31d
   sha: sha256:e20e4941ccd5706973068f9214d40cb2e669461536b3a57b9ac824ae87744c2c
 curator/vendor/s3transfer-0.3.3-py2.py3-none-any.whl:
   size: 69490
-  object_id: 31d3b0cf-7d3f-4760-7784-e976cd57f091
+  object_id: f8f215b7-4e4c-4adb-7d1a-bfd9f67fee60
   sha: sha256:2482b4259524933a022d59da830f51bd746db62f047d6eb213f2f8855dcb8a13
 curator/vendor/six-1.14.0-py2.py3-none-any.whl:
   size: 10938
-  object_id: 44b1f227-2ccf-49eb-68d4-93e6627a5df0
+  object_id: 2bc076f9-931b-480f-5704-a491b74515e2
   sha: sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c
 curator/vendor/voluptuous-0.11.5-py2.py3-none-any.whl:
   size: 27677
-  object_id: 30fbe47c-eb16-4db8-57ce-f853940769c7
-  sha: b5c82285df0610464a9332c567cf8bd06b8786f6
+  object_id: 6889d3b8-07e8-4e17-49a0-474405676494
+  sha: sha256:303542b3fc07fb52ec3d7a1c614b329cdbee13a9d681935353d8ea56a7bfa9f1
 elasticsearch/elasticsearch-7.6.1-linux-x86_64.tar.gz:
   size: 296454172
-  object_id: a7447f2a-1772-4892-508e-43e5029c54ba
+  object_id: 342f78ab-8c75-4ce5-72b2-7fd0541c3dad
   sha: sha256:25583ddd44a99437958f7f9410cd9746c8230b367d570cdf69e96824a583748a
 haproxy/haproxy-1.7.5.tar.gz:
   size: 1743979
-  object_id: 93570fdf-c123-4f81-6177-8384f4332e52
+  object_id: 4ee72933-de11-4d3c-4657-b6b284388def
   sha: sha256:b04d7db6383c662eb0a421a95af7becac6d9744a1abf0df6b0280c1e61416121
 haproxy/pcre-8.40.tar.gz:
   size: 2065161
-  object_id: edf51dad-4c6c-4a3d-8ebb-3a9b9f9641e5
-  sha: 10384eb3d411794cc15f55b9d837d3f69e35391e
+  object_id: 28786a5b-7b76-45af-578f-af8bd85ef90a
+  sha: sha256:1d75ce90ea3f81ee080cdc04e68c9c25a9fb984861a0618be7bbf676b18eda3e
 kibana/kibana-7.6.1-linux-x86_64.tar.gz:
   size: 249498863
-  object_id: df54821e-9deb-4c08-4f02-6f160dec5913
+  object_id: 50a70286-23e8-4c3f-7749-f10404a058bc
   sha: sha256:da636529511e707bbbc621dc131ff2ed18f50fe0df30821c375d16c5ba4248f6
 logstash/logstash-7.6.1.tar.gz:
   size: 172679481
-  object_id: 8f5d650d-58a2-4774-566a-519d8e085ae5
+  object_id: 6301a0c6-e294-4bd3-4b6a-306a7d66d0a8
   sha: sha256:6b16f3158829ad820463c7f3ca4cfec433d12d0eafa25be203c92d12ca91da10
 logstash/logstash-filter-alter-3.0.2.zip:
   size: 7425
-  object_id: 115e22b9-ef42-46e1-6d8d-d23deb9beaa1
+  object_id: c91d4188-e46c-4de9-70c8-5c087b26e134
   sha: sha256:35912163f4e1ad0960d7efe3283877236cf6462702e7dcb17a143568330e29a6
 logstash/logstash-filter-translate-3.0.3.zip:
   size: 10677
-  object_id: 12bcee74-879c-486e-7b4c-39731eff1089
+  object_id: dec19668-4409-46e5-4a8b-f89935ad4e52
   sha: sha256:743c100c51c63fe17a55487254b140a2a9c3fb5f532d7bc570f84e902839fe5b
 logstash/logstash-input-relp-3.0.2.zip:
   size: 12616
-  object_id: 717156b5-6027-4c7f-459f-091dc2710603
+  object_id: 261563e0-02ab-4d28-6e6f-2731edef10f3
   sha: sha256:98fae22f18468c7abea0969b2d714e853ac47686f537c5223b1ff12150b3eedb
 logstash/logstash-input-syslog-3.2.2.zip:
   size: 10966
-  object_id: 88ec3912-4366-492a-752c-25080365790d
-  sha: e73dc3326021fc57e8b73ba87b74255870aa69a2
+  object_id: 7fd274c2-8b00-48c1-4e73-f64b5cb6f50b
+  sha: sha256:4a799a41b507ff2f4d8b819df509937e24248760b7092f58814ba564fbb976ee
 logstash/logstash-output-syslog-3.0.5.zip:
   size: 9679
-  object_id: d1c0b0f1-b98b-41b6-4b00-08d3b1bb9467
+  object_id: 24e857cd-0865-41fb-706d-768690a82a50
   sha: sha256:eaac1ea66848d34dbe41e4126fffac4e221deecb402b310e64fd5bb41e3b870f
 nats_to_syslog/nats_to_syslog_linux_amd64.tar.gz:
   size: 2094679
-  object_id: c652847a-f5aa-44a5-43a8-e53a0020dbe3
+  object_id: 51e95b33-7375-492e-7ce6-c861579dd2dd
   sha: sha256:17da6f37f28006a98ac3697acdf0c901316f2a59cfcae1145586fa01e4fb7d6f
 python/Python-3.6.2.tgz:
   size: 22580749
-  object_id: 6f36a99a-6242-4fc8-571a-31f476cb0e03
+  object_id: 3c3b1136-1e31-4e8a-408c-8c51ee0f384e
   sha: sha256:7919489310a5f17f7acbab64d731e46dca0702874840dadce8bd4b2b3b8e7a82
 python/requests-2.21.0-py2.py3-none-any.whl:
   size: 57987
-  object_id: b0656e9b-3473-477e-6915-f3d2faff5484
+  object_id: dea5bedb-3b9a-4119-4046-f0ebef306592
   sha: sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b
 python/vendor/certifi-2019.3.9-py2.py3-none-any.whl:
   size: 158601
-  object_id: 16cfbb23-a56f-4e75-6df3-0fc8d32645a5
+  object_id: c61720cf-a199-4379-5d9f-c009f16a6e92
   sha: sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5
 python/vendor/chardet-3.0.4-py2.py3-none-any.whl:
   size: 133356
-  object_id: d184f433-b3da-4ab4-4aa3-55bd7a640d3a
+  object_id: 670d8fad-ccdf-41cc-66bb-fa54309b81c5
   sha: sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
 python/vendor/idna-2.8-py2.py3-none-any.whl:
   size: 58594
-  object_id: a58ac48b-666f-4d8d-53fc-fbb8c028c732
+  object_id: 5d59d9c1-237f-41f2-7583-ca7e75c88e83
   sha: sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c
 python/vendor/urllib3-1.24.2-py2.py3-none-any.whl:
   size: 131747
-  object_id: cb2f587e-73a9-4ff5-74f0-ad55803baf93
+  object_id: 625b335b-ab64-4496-63b4-e14469aea27d
   sha: sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0
 ruby/rake-12.3.2.gem:
   size: 87040
-  object_id: d8da7191-86a0-4a59-4d55-08a615ad3239
+  object_id: f3da806d-51e4-4ca6-5ba3-6a846f08269e
   sha: sha256:56362f144a29ffbc5e49161a80ca4e2e6b7da2946170067d624d7603ed51c5eb

--- a/jobs/syslog_forwarder/templates/bin/pre-start
+++ b/jobs/syslog_forwarder/templates/bin/pre-start
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+mkdir -p /var/vcap/sys/run/rsyslogd
+chown syslog /var/vcap/sys/run/rsyslogd/
+
+<% p("syslog_forwarder.config").each do |config| %>
+mkdir -p $(dirname "<%= config["file"] %>")
+<% end %>
+
+cp /var/vcap/jobs/syslog_forwarder/config/rsyslog_file_forwarder.conf /etc/rsyslog.d/
+service rsyslog restart

--- a/jobs/syslog_forwarder/templates/config/rsyslog_file_forwarder.conf
+++ b/jobs/syslog_forwarder/templates/config/rsyslog_file_forwarder.conf
@@ -1,0 +1,54 @@
+<% if p("syslog_forwarder.config").any? %>
+
+<%
+  networks = spec.networks.marshal_dump.values
+  network = networks.find do |network_spec|
+    network_spec.default
+  end
+
+  network ||= networks.first
+  job_ip = network.ip
+%>
+
+module(load="imfile")
+$WorkDirectory /var/vcap/sys/run/rsyslogd
+
+<% p("syslog_forwarder.config").each do |config| %>
+input(type="imfile"
+  File="<%= config["file"] %>"
+  Tag="<%= config["service"] %>"
+  Ruleset="ToMonitor")
+
+<% end %>
+
+template(name="fileForwarding" type="list") {
+  constant(value="<")
+  property(name="pri")
+  constant(value=">")
+  constant(value="1 ")
+  property(name="timestamp" dateFormat="rfc3339")
+  constant(value=" <%= job_ip %> ")
+  property(name="programname")
+  constant(value=" - - [- job=<%= name %> index=<%= index %>] ")
+  property(name="msg")
+}
+
+<%
+  syslog_forwarder_host = nil
+  if_link("syslog_forwarder") { |syslog_forwarder_link| syslog_forwarder_host = syslog_forwarder_link.instances.first.address }
+  unless syslog_forwarder_host
+    syslog_forwarder_host = p("syslog_forwarder.host")
+  end
+
+  syslog_forwarder_port = nil
+  if_link("syslog_forwarder") { |syslog_forwarder_link| syslog_forwarder_port = syslog_forwarder_link.p("logstash_ingestor.syslog.port") }
+  unless syslog_forwarder_port
+    syslog_forwarder_port = p("syslog_forwarder.port")
+  end
+%>
+
+ruleset(name="ToMonitor") {
+  action(type="omfwd" Target="<%= syslog_forwarder_host %>" Port="<%= syslog_forwarder_port %>" Protocol="tcp" Template="fileForwarding")
+}
+
+<% end %>


### PR DESCRIPTION
## Changes proposed in this pull request:

Restores syslog_forwarder to match upstream. This requires an ops file and therefore should not have an impact (aside from being closer to the upstream and building successfully).

## security considerations

None
