### PR TITLE
add syslog_forwarder to match upstream

### DIFF
--- a/jobs/syslog_forwarder/templates/bin/pre-start
+++ b/jobs/syslog_forwarder/templates/bin/pre-start
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+mkdir -p /var/vcap/sys/run/rsyslogd
+chown syslog /var/vcap/sys/run/rsyslogd/
+
+<% p("syslog_forwarder.config").each do |config| %>
+mkdir -p $(dirname "<%= config["file"] %>")
+<% end %>
+
+cp /var/vcap/jobs/syslog_forwarder/config/rsyslog_file_forwarder.conf /etc/rsyslog.d/
+service rsyslog restart

--- a/jobs/syslog_forwarder/templates/config/rsyslog_file_forwarder.conf
+++ b/jobs/syslog_forwarder/templates/config/rsyslog_file_forwarder.conf
@@ -1,0 +1,54 @@
+<% if p("syslog_forwarder.config").any? %>
+
+<%
+  networks = spec.networks.marshal_dump.values
+  network = networks.find do |network_spec|
+    network_spec.default
+  end
+
+  network ||= networks.first
+  job_ip = network.ip
+%>
+
+module(load="imfile")
+$WorkDirectory /var/vcap/sys/run/rsyslogd
+
+<% p("syslog_forwarder.config").each do |config| %>
+input(type="imfile"
+  File="<%= config["file"] %>"
+  Tag="<%= config["service"] %>"
+  Ruleset="ToMonitor")
+
+<% end %>
+
+template(name="fileForwarding" type="list") {
+  constant(value="<")
+  property(name="pri")
+  constant(value=">")
+  constant(value="1 ")
+  property(name="timestamp" dateFormat="rfc3339")
+  constant(value=" <%= job_ip %> ")
+  property(name="programname")
+  constant(value=" - - [- job=<%= name %> index=<%= index %>] ")
+  property(name="msg")
+}
+
+<%
+  syslog_forwarder_host = nil
+  if_link("syslog_forwarder") { |syslog_forwarder_link| syslog_forwarder_host = syslog_forwarder_link.instances.first.address }
+  unless syslog_forwarder_host
+    syslog_forwarder_host = p("syslog_forwarder.host")
+  end
+
+  syslog_forwarder_port = nil
+  if_link("syslog_forwarder") { |syslog_forwarder_link| syslog_forwarder_port = syslog_forwarder_link.p("logstash_ingestor.syslog.port") }
+  unless syslog_forwarder_port
+    syslog_forwarder_port = p("syslog_forwarder.port")
+  end
+%>
+
+ruleset(name="ToMonitor") {
+  action(type="omfwd" Target="<%= syslog_forwarder_host %>" Port="<%= syslog_forwarder_port %>" Protocol="tcp" Template="fileForwarding")
+}
+
+<% end %>


### PR DESCRIPTION
## Changes proposed in this pull request:

Add syslog_forwarder to match the upstream. Activation requires an ops file so this should have no effect (other than allowing the build to succeed and being closer to the upstream)

## security considerations

None
