### PR TITLE
use the same tmp directory other jobs use

### DIFF
--- a/jobs/archiver_syslog/templates/config/jvm.options.erb
+++ b/jobs/archiver_syslog/templates/config/jvm.options.erb
@@ -1,4 +1,4 @@
 # the default /tmp dir is often noexec, so we need to use one that is not.
--Djava.io.tmpdir=/var/vcap/data/sys/tmp/archiver_syslog
+-Djava.io.tmpdir=/var/vcap/sys/tmp/archiver_syslog
 
 <% p('logstash.jvm_options').each do |opt| %><%= opt %><% end %>


### PR DESCRIPTION
## Changes proposed in this pull request:

The archiver_syslog job is failing with:

"[ERROR] 2020-08-28 15:47:51.707 [main] Logstash - java.lang.IllegalStateException: Logstash stopped processing because of an error: (GemspecError) 
[!] There was an error while loading `logstash-core-plugin-api.gemspec`: load error: psych -- java.lang.RuntimeException: BUG: we can not copy embedded jar to temp directory
Does it try to require a relative path? That's been removed in Ruby 1.9. Bundler cannot continue."

This appears to be an error writing to the temp directory. The `/var/vcap/sys/data/tmp/archiver_syslog` directory does not exist. The other jobs are also configured to use `/var/vcap/sys/tmp/$JOB_NAME`. For example: https://github.com/cloudfoundry-community/logsearch-boshrelease/blob/7e56a1e8bc01bef3c8217369af7f182140004a80/jobs/ingestor_syslog/templates/config/jvm.options.erb#L2



## security considerations

None
