### PR TITLE
use strings for code comparison

### DIFF
--- a/jobs/kibana/templates/bin/post-start.erb
+++ b/jobs/kibana/templates/bin/post-start.erb
@@ -10,7 +10,7 @@ elapsed=0
 until [ $elapsed -ge <%= p("kibana.health.timeout") %> ]
 do
   CODE=`curl -s -o /dev/null -w "%{http_code}" http://<%= p("kibana.host") %>:<%= p("kibana.port") %>`
-  if [[ $CODE == 302 ]]; then
+  if [[ "$CODE" == "302" ]]; then
     echo Done!
     break
   fi


### PR DESCRIPTION
## Changes proposed in this pull request:

We can see return codes of `000` when kibana is still starting before the network is availble. `000` causes the if statement evaluation to fail when it is evaluated as a number. Therefore, we want to do a string comparison.

TODO: submit an upstream PR after we test this.

## security considerations

None
