### PR TITLE
curl response code of 000 should not cause the script to exit

### DIFF
--- a/jobs/kibana/templates/bin/post-start.erb
+++ b/jobs/kibana/templates/bin/post-start.erb
@@ -9,7 +9,11 @@ echo "Waiting <%= p("kibana.health.timeout") %>s for kibana to accept connection
 elapsed=0
 until [ $elapsed -ge <%= p("kibana.health.timeout") %> ]
 do
+  # We have to set and unset the 'e' flag around the curl as a return code of 000 (no network) will result in an error.
+  # This return code is valid and therefore we want to ignore this as an error.
+  set +e
   CODE=`curl -s -o /dev/null -w "%{http_code}" http://<%= p("kibana.host") %>:<%= p("kibana.port") %>`
+  set -e
   if [[ "$CODE" == "302" ]]; then
     echo Done!
     break


### PR DESCRIPTION
## Changes proposed in this pull request:

We use `set -e` in many of our scripts to stop execution on error. In the case of curling kibana, we can receive a return code of 000 denoting the network is unavailable. This occurs when kibana is restarting. Curl returns this as an error causing the script to prematurely exit. Given this isn't an error in our situation, we need to `set +e` before the curl and `set -e` after.

## security considerations

none
