### PR TITLE
set java tempdir

### DIFF
--- a/jobs/archiver_syslog/templates/bin/archiver_syslog_ctl
+++ b/jobs/archiver_syslog/templates/bin/archiver_syslog_ctl
@@ -31,7 +31,7 @@ case $1 in
     # store this processes pid in $PIDFILE, since the exec below doesn't daemonize
     echo $$ > $PIDFILE
 
-    export LS_JAVA_OPTS="-Xms$HEAP_SIZE -Xmx$HEAP_SIZE -DPID=$$"
+    export LS_JAVA_OPTS="-Xms$HEAP_SIZE -Xmx$HEAP_SIZE -DPID=$$ -Djava.io.tmpdir=/var/vcap/sys/temp/archiver_syslog"
 
     <% p("logstash.plugins").each do |plugin| %>
     /var/vcap/packages/logstash/bin/logstash-plugin install \


### PR DESCRIPTION
## Changes proposed in this pull request:

The jobs/archiver_syslog/templates/config/jvm.options.erb is not referenced by the upstream and therefore I am unsure it is being read. This commit explicitly sets the temp director for java.

## security considerations

None
