### PR TITLE
bpm controls the ulimit setting now

### DIFF
--- a/jobs/archiver_syslog/templates/bin/archiver_syslog
+++ b/jobs/archiver_syslog/templates/bin/archiver_syslog
@@ -40,8 +40,6 @@ if cat $LOG_DIR/$JOB_NAME.stdout.log | grep -a 'QueueUpgrade - Logstash was unab
   mv $LOG_DIR/$JOB_NAME.stdout.log $LOG_DIR/$JOB_NAME.stdout.log.old
 fi
 
-ulimit -n <%= p("logstash_archiver.files") %>
-
 /var/vcap/packages/logstash/bin/logstash \
 --path.data ${STORE_DIR} \
 --path.config ${JOB_DIR}/config/logstash.conf \

--- a/jobs/archiver_syslog/templates/config/bpm.yml.erb
+++ b/jobs/archiver_syslog/templates/config/bpm.yml.erb
@@ -5,6 +5,8 @@ processes:
     executable: /var/vcap/jobs/archiver_syslog/bin/archiver_syslog.sh
     ephemeral_disk: true
     persistent_disk: true
+    limits:
+      open_files: <%= p("logstash_archiver.files") %>
     additional_volumes:
     - path: /var/vcap/sys/tmp/archiver_syslog
       writable: true


### PR DESCRIPTION
## Changes proposed in this pull request:

Move the ulimit setting from the archiver_syslog script into BPM as per: https://bosh.io/docs/bpm/runtime/#open-files and https://bosh.io/docs/bpm/config/#limits-schema

## security considerations

None
