### PR TITLE
ensure jvm.options are parsed as config

### DIFF
--- a/jobs/archiver_syslog/templates/bin/archiver_syslog
+++ b/jobs/archiver_syslog/templates/bin/archiver_syslog
@@ -44,7 +44,10 @@ ulimit -n <%= p("logstash_archiver.files") %>
 
 /var/vcap/packages/logstash/bin/logstash \
 --path.data ${STORE_DIR} \
---path.config ${JOB_DIR}/config/logstash.conf \
+--path.config ${JOB_DIR}/config/{logstash.conf,jvm.options} \
 --path.settings ${JOB_DIR}/config \
 --pipeline.workers ${LOGSTASH_WORKERS} \
---log.format=json --log.level=<%= p("logstash.log_level") %>
+--log.format=json \
+--log.level=<%= p("logstash.log_level") %> \
+--path.logs /var/vcap/sys/log/${JOB_DIR}
+


### PR DESCRIPTION
## Changes proposed in this pull request:

1) Passes the jvm.options file as a config file to the logstash process. Debug logging showed the jvm.options file was being skipped as it was not provided as a glob pattern to the --path.config property.

2) Sets the --path.logs property. Without this property set, changing the --log.level had no effect.  


## security considerations

None
