### PR TITLE
set tmpdir in start script only

### DIFF
--- a/jobs/archiver_syslog/spec
+++ b/jobs/archiver_syslog/spec
@@ -17,7 +17,6 @@ templates:
   config/syslog_tls.crt.erb: config/syslog_tls.crt
   config/syslog_tls.key.erb: config/syslog_tls.key
   config/logstash.yml.erb: config/logstash.yml
-  config/jvm.options.erb: config/jvm.options
 
 provides:
 - name: archiver

--- a/jobs/archiver_syslog/templates/bin/archiver_syslog
+++ b/jobs/archiver_syslog/templates/bin/archiver_syslog
@@ -28,7 +28,7 @@ HEAP_SIZE=<%= heap_size %>
 export <%= env.keys[0] %>="<%= env.values[0] %>"
 <% end %>
 
-export LS_JAVA_OPTS="-Xms$HEAP_SIZE -Xmx$HEAP_SIZE -DPID=$$"
+export LS_JAVA_OPTS="-Xms$HEAP_SIZE -Xmx$HEAP_SIZE -DPID=$$ -Djava.io.tmpdir=/var/vcap/sys/tmp/${JOB_NAME}"
 
 # construct a complete config file from all the fragments
 cat ${JOB_DIR}/config/input_and_output.conf > ${JOB_DIR}/config/logstash.conf
@@ -42,7 +42,7 @@ fi
 
 /var/vcap/packages/logstash/bin/logstash \
 --path.data ${STORE_DIR} \
---path.config "${JOB_DIR}/config/{logstash.conf,jvm.options}" \
+--path.config ${JOB_DIR}/config/logstash.conf \
 --path.settings ${JOB_DIR}/config \
 --pipeline.workers ${LOGSTASH_WORKERS} \
 --log.format=json \

--- a/jobs/archiver_syslog/templates/config/jvm.options.erb
+++ b/jobs/archiver_syslog/templates/config/jvm.options.erb
@@ -1,4 +1,0 @@
-# the default /tmp dir is often noexec, so we need to use one that is not.
--Djava.io.tmpdir=/var/vcap/sys/tmp/archiver_syslog
-
-<% p('logstash.jvm_options').each do |opt| %><%= opt %><% end %>


### PR DESCRIPTION
## Changes proposed in this pull request:

The tmpdir appears to be getting set in different places. This commit moves the tmp dir to the start script along side the other directory inputs.

## security considerations

None
