### PR TITLE
allow curl up to a second to return to prevent backed up calls

### DIFF
--- a/jobs/kibana/templates/bin/post-start.erb
+++ b/jobs/kibana/templates/bin/post-start.erb
@@ -12,7 +12,7 @@ do
   # We have to set and unset the 'e' flag around the curl as a return code of 000 (no network) will result in an error.
   # This return code is valid and therefore we want to ignore this as an error.
   set +e
-  CODE=`curl -s -o /dev/null -w "%{http_code}" http://<%= p("kibana.host") %>:<%= p("kibana.port") %>`
+  CODE=`curl -m 1 -s -o /dev/null -w "%{http_code}" http://<%= p("kibana.host") %>:<%= p("kibana.port") %>`
   set -e
   if [[ "$CODE" == "302" ]]; then
     echo Done!


### PR DESCRIPTION
## Changes proposed in this pull request:

This fix sets a limit of 1 second for the post start health check curl to complete. Without this, the curl request could take an arbitrary amount of time causing the 600 second timeout to be exceeded before the script returned. This would lead to bosh spawning new post start processes, causing more contention.


## security considerations

none

