### PR TITLE
install pylibyaml before curator

### DIFF
--- a/packages/curator/packaging
+++ b/packages/curator/packaging
@@ -7,4 +7,5 @@ export PATH="/var/vcap/packages/python3/bin:${PATH}" LD_LIBRARY_PATH="/var/vcap/
 # --find-links tells pip where to look for the dependancies
 # --prefix installation prefix where lib, bin and other top-level folders are placed
 pip3 install --no-index "--prefix=${BOSH_INSTALL_TARGET}" curator/vendor/PyYAML-3.12.zip
+pip3 install --no-index "--prefix=${BOSH_INSTALL_TARGET}" curator/vendor/pylibyaml-0.1.0-py3-none-any.whl
 pip3 install --no-index --find-links ./curator/vendor/ "--prefix=${BOSH_INSTALL_TARGET}" curator/elasticsearch-curator-v5.7.6.tar.gz


### PR DESCRIPTION
## Changes proposed in this pull request:

Installs pylibyaml before curator. The compilation is failing on the latest stemcell with 'libyaml is not found or a compiler error'

## security considerations

None
