### PR TITLE
match curator name to blob

### DIFF
--- a/packages/curator/packaging
+++ b/packages/curator/packaging
@@ -9,4 +9,4 @@ export PATH="/var/vcap/packages/python3/bin:${PATH}" LD_LIBRARY_PATH="/var/vcap/
 # --find-links tells pip where to look for the dependancies
 # --prefix installation prefix where lib, bin and other top-level folders are placed
 pip3 install --no-index "--prefix=${BOSH_INSTALL_TARGET}" curator/vendor/PyYAML-3.13.tar.gz
-pip3 install --no-index --find-links ./curator/vendor/ "--prefix=${BOSH_INSTALL_TARGET}" curator/elasticsearch-curator-v5.8.3.tar.gz
+pip3 install --no-index --find-links ./curator/vendor/ "--prefix=${BOSH_INSTALL_TARGET}" curator/elasticsearch-curator-5.8.3.tar.gz

--- a/packages/curator/spec
+++ b/packages/curator/spec
@@ -5,7 +5,7 @@ dependencies:
   - python3
 
 files:
-  - curator/elasticsearch-curator-v5.8.3.tar.gz
+  - curator/elasticsearch-curator-5.8.3.tar.gz
   - curator/vendor/elasticsearch-7.1.0-py2.py3-none-any.whl
   - curator/vendor/boto3-1.12.36-py2.py3-none-any.whl
   - curator/vendor/requests_aws4auth-0.9-py2.py3-none-any.whl


### PR DESCRIPTION
## Changes proposed in this pull request:

Removes extraneous 'v' from curator name to match the blob.

## security considerations

None
