### PR TITLE
fixes to make java happy for new elasticsearch

### DIFF
--- a/jobs/elasticsearch/templates/config/jvm.options.erb
+++ b/jobs/elasticsearch/templates/config/jvm.options.erb
@@ -32,10 +32,6 @@
 ##
 ################################################################
 
-## GC configuration
--XX:+UseConcMarkSweepGC
--XX:CMSInitiatingOccupancyFraction=75
--XX:+UseCMSInitiatingOccupancyOnly
 
 ## optimizations
 

--- a/packages/elasticsearch/packaging
+++ b/packages/elasticsearch/packaging
@@ -1,3 +1,5 @@
 set -e
 
 tar xzf elasticsearch/elasticsearch-7.9.3-linux-x86_64.tar.gz -C $BOSH_INSTALL_TARGET --strip-components 1
+
+chown -R root:vcap elasticsearch/jdk


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove old JVM flags. See: https://github.com/elastic/elasticsearch/issues/51361#issuecomment-707423698
- chown jdk so vcap can run java
-

## security considerations
None