### PR TITLE
switch to component templates

### DIFF
--- a/jobs/elasticsearch_config/spec
+++ b/jobs/elasticsearch_config/spec
@@ -24,8 +24,11 @@ properties:
       It is used in the index templates predefined in the job to specify index pattern.
       Make sure the prefix matches `logstash_parser.elasticsearch.index` property set for your parser.
     default: "logstash-"
-  elasticsearch_config.templates:
-    description: "An array with key-value hashes; keys being template name, value being template content"
+  elasticsearch_config.component_templates:
+    description: "An array of key-value hashes; keys being component template name, value being template path or content"
+    default: []
+  elasticsearch_config.index_templates:
+    description: "An array with key-value hashes; keys being template name, value being template path or content"
     default: []
   elasticsearch_config.docs:
     description: "An array with key-value hashes; keys being doc path, value being doc source"

--- a/jobs/elasticsearch_config/templates/bin/upload-config.erb
+++ b/jobs/elasticsearch_config/templates/bin/upload-config.erb
@@ -85,8 +85,12 @@ end
 
 until curl -sf 'http://<%= elasticsearch_host %>:<%= elasticsearch_port %>/_cluster/health?wait_for_status=yellow&timeout=10m'; do :; done
 
-echo "--- Templates"
+echo "--- Component Templates"
+<%= put_to_es('_component_template', p('elasticsearch_config.component_templates')) %>
+
+echo "--- Index Templates"
 <%= put_to_es('_index_template', p('elasticsearch_config.templates')) %>
+
 
 echo "--- Documents"
 <%= put_to_es('', p('elasticsearch_config.docs')) %>

--- a/jobs/elasticsearch_config/templates/bin/upload-config.erb
+++ b/jobs/elasticsearch_config/templates/bin/upload-config.erb
@@ -89,7 +89,7 @@ echo "--- Component Templates"
 <%= put_to_es('_component_template', p('elasticsearch_config.component_templates')) %>
 
 echo "--- Index Templates"
-<%= put_to_es('_index_template', p('elasticsearch_config.templates')) %>
+<%= put_to_es('_index_template', p('elasticsearch_config.index_templates')) %>
 
 
 echo "--- Documents"

--- a/jobs/elasticsearch_config/templates/bin/upload-config.erb
+++ b/jobs/elasticsearch_config/templates/bin/upload-config.erb
@@ -86,7 +86,7 @@ end
 until curl -sf 'http://<%= elasticsearch_host %>:<%= elasticsearch_port %>/_cluster/health?wait_for_status=yellow&timeout=10m'; do :; done
 
 echo "--- Templates"
-<%= put_to_es('_template', p('elasticsearch_config.templates')) %>
+<%= put_to_es('_index_template', p('elasticsearch_config.templates')) %>
 
 echo "--- Documents"
 <%= put_to_es('', p('elasticsearch_config.docs')) %>

--- a/jobs/elasticsearch_config/templates/index-templates/index-mappings.json.erb
+++ b/jobs/elasticsearch_config/templates/index-templates/index-mappings.json.erb
@@ -1,43 +1,43 @@
 {
-  "template": "<%= p('elasticsearch_config.index_prefix') %>*",
-  "order": 102,
-  "settings": {
-    "index": {
-      "query": {
-        "default_field": "@raw"
-      }
-    }
-  },
-  "mappings": {
-    "dynamic_templates": [
-      {
-        "string_fields": {
-          "match": "*",
-          "match_mapping_type": "string",
-          "mapping": {
-            "type": "keyword",
-            "index": true,
-            "norms": false
-          }
+  "template": {
+    "settings": {
+      "index": {
+        "query": {
+          "default_field": "@raw"
         }
       }
-    ],
-    "properties": {
-      "@version": {
-        "type": "keyword",
-        "index": true
-      },
-      "@raw": {
-        "type": "text",
-        "index": true,
-        "norms": false
-      },
-      "geoip": {
-        "type": "object",
-        "dynamic": true,
-        "properties": {
-          "location": {
-            "type": "geo_point"
+    },
+    "mappings": {
+      "dynamic_templates": [
+        {
+          "string_fields": {
+            "match": "*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "keyword",
+              "index": true,
+              "norms": false
+            }
+          }
+        }
+      ],
+      "properties": {
+        "@version": {
+          "type": "keyword",
+          "index": true
+        },
+        "@raw": {
+          "type": "text",
+          "index": true,
+          "norms": false
+        },
+        "geoip": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "location": {
+              "type": "geo_point"
+            }
           }
         }
       }

--- a/jobs/elasticsearch_config/templates/index-templates/index-settings.json.erb
+++ b/jobs/elasticsearch_config/templates/index-templates/index-settings.json.erb
@@ -1,21 +1,21 @@
 {
-  "template": "<%= p('elasticsearch_config.index_prefix') %>*",
-  "order": 101,
-  "settings": { 
-    "index": {
-      "codec": "best_compression",
-      "search": {
-        "slowlog": {
-          "threshold": {
-            "query": {
-              "warn": "30s",
-              "info": "15s",
-              "debug": "10s",
-              "trace": "5s"
+  "template": {
+    "settings": { 
+      "index": {
+        "codec": "best_compression",
+        "search": {
+          "slowlog": {
+            "threshold": {
+              "query": {
+                "warn": "30s",
+                "info": "15s",
+                "debug": "10s",
+                "trace": "5s"
+              }
             }
           }
-        }
-      }      
-    }    
+        }      
+      }    
+    }
   }
 }

--- a/jobs/elasticsearch_config/templates/index-templates/shards-and-replicas.json.erb
+++ b/jobs/elasticsearch_config/templates/index-templates/shards-and-replicas.json.erb
@@ -1,4 +1,5 @@
 {
+  "template": {
     "settings": { 
       "number_of_shards": 5,
       "number_of_replicas" : 1

--- a/jobs/elasticsearch_config/templates/index-templates/shards-and-replicas.json.erb
+++ b/jobs/elasticsearch_config/templates/index-templates/shards-and-replicas.json.erb
@@ -1,6 +1,7 @@
 {
-  "settings": { 
-    "number_of_shards": 5,
-    "number_of_replicas" : 1    
+    "settings": { 
+      "number_of_shards": 5,
+      "number_of_replicas" : 1
+    }
   }
 }

--- a/jobs/elasticsearch_config/templates/index-templates/shards-and-replicas.json.erb
+++ b/jobs/elasticsearch_config/templates/index-templates/shards-and-replicas.json.erb
@@ -1,6 +1,4 @@
 {
-  "template": "<%= p('elasticsearch_config.index_prefix') %>*",
-  "order": 100,
   "settings": { 
     "number_of_shards": 5,
     "number_of_replicas" : 1    


### PR DESCRIPTION
## Changes proposed in this pull request:
- switch to component templates. Note that this needs to be coordinated with updates to logsearch-for-cloudfoundry and cg-deploy-logsearch

## security considerations
None