### PR TITLE
use the correct variable name

### DIFF
--- a/jobs/archiver_syslog/templates/bin/archiver_syslog
+++ b/jobs/archiver_syslog/templates/bin/archiver_syslog
@@ -47,5 +47,5 @@ fi
 --pipeline.workers ${LOGSTASH_WORKERS} \
 --log.format=json \
 --log.level=<%= p("logstash.log_level") %> \
---path.logs /var/vcap/sys/log/${JOB_DIR}
+--path.logs /var/vcap/sys/log/${JOB_NAME}
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Use the variable $JOB_NAME in place of $JOB_DIR for the logs-path. This should result in a value of: `/var/vcap/sys/log/archiver_syslog` rather than `/var/vcap/sys/log//var/vcap/jobs/archiver_syslog`. I am not sure this matters as the lgos are appearing in the correct directory, but it should still be changed.


## security considerations

None
