### PR TITLE
Smoketests fix

### DIFF
--- a/jobs/smoke_tests/templates/run.sh
+++ b/jobs/smoke_tests/templates/run.sh
@@ -38,7 +38,7 @@ LOG="<13>$(date -u +"%Y-%m-%dT%H:%M:%SZ") 0.0.0.0 smoke-test-errand [job=smoke_t
 <% if p('smoke_tests.use_tls') %>
 INGEST="openssl s_client -connect $INGESTOR_HOST:$INGESTOR_PORT"
 <% else %>
-INGEST="nc $INGESTOR_HOST $INGESTOR_PORT"
+INGEST="nc -q 1 $INGESTOR_HOST $INGESTOR_PORT"
 <% end %>
 
 echo "SENDING $LOG"

--- a/jobs/smoke_tests/templates/run.sh
+++ b/jobs/smoke_tests/templates/run.sh
@@ -38,7 +38,7 @@ LOG="<13>$(date -u +"%Y-%m-%dT%H:%M:%SZ") 0.0.0.0 smoke-test-errand [job=smoke_t
 <% if p('smoke_tests.use_tls') %>
 INGEST="openssl s_client -connect $INGESTOR_HOST:$INGESTOR_PORT"
 <% else %>
-INGEST="nc -q 1 $INGESTOR_HOST $INGESTOR_PORT"
+INGEST="nc -q 5 $INGESTOR_HOST $INGESTOR_PORT"
 <% end %>
 
 echo "SENDING $LOG"


### PR DESCRIPTION
## Changes proposed in this pull request:
- `nc` on Bionic does not exit during the pipe - adding `-q 5` tells `nc` to wait 5 seconds once connected before exit
- This fix works on both `xenial` and `bionic` stemcells

## security considerations
n/a