### PR TITLE
Update Java JDK to latest release

### DIFF
--- a/packages/openjdk-11/spec.lock
+++ b/packages/openjdk-11/spec.lock
@@ -1,2 +1,2 @@
 name: openjdk-11
-fingerprint: eac196ff6123e45a9547009e7931674bf5815bc642fdf73ce0f0d7c3f4ea520e
+fingerprint: 3ef431881fcab611d6b26a6a6b27f6603b383ec2d7600adf318116fccce5a702


### PR DESCRIPTION
This changeset updates the Java JDK to the latest BOSH release available to address security patches.

## Changes proposed in this pull request:
- Updates the Java JDK to the latest series 11 release from the BOSH [`java-release`](https://github.com/bosh-packages/java-release)

## Security considerations:
- Address recent security vulnerabilities that have been patched