### PR TITLE
use ips for bootstrapping

### DIFF
--- a/jobs/elasticsearch/templates/config/config.yml.erb
+++ b/jobs/elasticsearch/templates/config/config.yml.erb
@@ -32,7 +32,7 @@ opendistro_security:
     cluster_name = p("elasticsearch.cluster_name")
   end
   master_hosts = nil
-  if_link("elasticsearch") { |elasticsearch_link| master_hosts = elasticsearch_link.instances.map {|e| e.address}.join(',') }
+  if_link("elasticsearch") { |elasticsearch_link| master_hosts = elasticsearch_link.instances.map {|e| e.ip}.join(',') }
   unless master_hosts
     master_hosts = p("elasticsearch.master_hosts").join(',')
   end


### PR DESCRIPTION
## Changes proposed in this pull request:
- use ips for bootstrapping. When using hostnames for bootstrapping, elasticsearch assumes the node name will match the host name, but in our case it doesn't. Using IP addresses works around this


## security considerations
None