### PR TITLE
Remove useless file that trips up Nessus

### DIFF
--- a/packages/elasticsearch/packaging
+++ b/packages/elasticsearch/packaging
@@ -3,3 +3,5 @@ set -e
 tar xzf elasticsearch/elasticsearch-7.9.3-linux-x86_64.tar.gz -C $BOSH_INSTALL_TARGET --strip-components 1
 
 chown -R root:vcap "${BOSH_INSTALL_TARGET}/jdk"
+
+/bin/rm -f "${BOSH_INSTALL_TARGET}/bin/elasticsearch-sql-cli-7.9.3.jar"

--- a/packages/elasticsearch/packaging
+++ b/packages/elasticsearch/packaging
@@ -4,4 +4,5 @@ tar xzf elasticsearch/elasticsearch-7.9.3-linux-x86_64.tar.gz -C $BOSH_INSTALL_T
 
 chown -R root:vcap "${BOSH_INSTALL_TARGET}/jdk"
 
+# For log4j 2.14 or older. Remove after we update Elasticsearch to 7.16.2 or higher. 
 /bin/rm -f "${BOSH_INSTALL_TARGET}/bin/elasticsearch-sql-cli-7.9.3.jar"


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- This file is triggering our Nessus scanner. It's a legitimate result. It's not a vulnerability because it's only susceptible when used on the CLI, but it's easier to just `rm` it instead of trying to explain.
- Using -f so this works after we upgrade Elasticsearch. 

## security considerations
This removes a file with a known exploit. 
