### PR TITLE
decouple elasticsearch version from JDK version

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -74,10 +74,10 @@ curator/vendor/voluptuous-0.11.5-py2.py3-none-any.whl:
   size: 27677
   object_id: 6889d3b8-07e8-4e17-49a0-474405676494
   sha: sha256:303542b3fc07fb52ec3d7a1c614b329cdbee13a9d681935353d8ea56a7bfa9f1
-elasticsearch/elasticsearch-7.9.3-linux-x86_64.tar.gz:
-  size: 306436527
-  object_id: b2475aef-c383-4a5e-597f-669699394a8d
-  sha: sha256:ae815dca86b0a567185f3f6d4fad047b2f8b6f38c1eee424291cc527261c1c5c
+elasticsearch/elasticsearch-7.9.3-no-jdk-linux-x86_64.tar.gz:
+  size: 162808745
+  object_id: e3856ece-c8a3-4c2b-6097-53a75ee5eeca
+  sha: sha256:2ab0e23277e2fd9365b53af2653e6107ab46db2117390e84ba53385a96f3559f
 haproxy/haproxy-1.7.5.tar.gz:
   size: 1743979
   object_id: 4ee72933-de11-4d3c-4657-b6b284388def

--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -19,7 +19,7 @@ templates:
   config/node-pem.erb: config/ssl/elasticsearch-node.pem
   config/admin-crt.erb: config/ssl/elasticsearch-admin.crt
   config/admin-pem.erb: config/ssl/elasticsearch-admin.pem
-  config/jvm.options.erb: config/jvm.options
+  config/jvm.options.erb: config/jvm.options.d/custom
   config/log4j2.properties.erb: config/log4j2.properties
 
 provides:

--- a/jobs/elasticsearch/templates/bin/elasticsearch
+++ b/jobs/elasticsearch/templates/bin/elasticsearch
@@ -9,6 +9,7 @@ export LANG=en_US.UTF-8
 export TMP_DIR=/var/vcap/sys/tmp/$JOB_NAME
 export JOB_DIR=/var/vcap/jobs/$JOB_NAME
 export LOG_DIR=/var/vcap/sys/log/$JOB_NAME
+source /var/vcap/packages/openjdk-11/bosh/runtime.env
 
 <% p("elasticsearch.exec.environment", {}).each do |k, v| %>
 export <%= k %>=<%= v %>
@@ -19,7 +20,8 @@ export HEAP_SIZE=$((( $( cat /proc/meminfo | grep MemTotal | awk '{ print $2 }' 
   HEAP_SIZE=<%= heap_size %>
 <% end %>
 
-export ES_JAVA_OPTS="-Xms$HEAP_SIZE -Xmx$HEAP_SIZE -Djava.io.tmpdir=$TMP_DIR"
+export ES_JAVA_OPTS="-Xms$HEAP_SIZE -Xmx$HEAP_SIZE"
+export ES_TMPDIR="$TMP_DIR"
 export ES_PATH_CONF=${JOB_DIR}/config
 
 export MAX_OPEN_FILES=<%= p("elasticsearch.limits.fd") %>

--- a/jobs/elasticsearch/templates/config/jvm.options.erb
+++ b/jobs/elasticsearch/templates/config/jvm.options.erb
@@ -35,78 +35,15 @@
 
 ## optimizations
 
-# disable calls to System#gc
--XX:+DisableExplicitGC
-
-# pre-touch memory pages used by the JVM during initialization
--XX:+AlwaysPreTouch
-
-## basic
-
-# force the server VM (remove on 32-bit client JVMs)
--server
-
-# explicitly set the stack size (reduce to 320k on 32-bit client JVMs)
--Xss1m
-
-# set to headless, just in case
--Djava.awt.headless=true
-
 # ensure UTF-8 encoding by default (e.g. filenames)
 -Dfile.encoding=UTF-8
 
 # use our provided JNA always versus the system one
 -Djna.nosys=true
 
-# use old-style file permissions on JDK9
--Djdk.io.permissionsUseCanonicalPath=true
-
-# flags to configure Netty
--Dio.netty.noUnsafe=true
--Dio.netty.noKeySetOptimization=true
--Dio.netty.recycler.maxCapacityPerThread=0
-
 # log4j 2
 -Dlog4j.shutdownHookEnabled=false
 -Dlog4j2.disable.jmx=true
 -Dlog4j.skipJansi=true
-
-## heap dumps
-
-# generate a heap dump when an allocation from the Java heap fails
-# heap dumps are created in the working directory of the JVM
--XX:+HeapDumpOnOutOfMemoryError
-
-# specify an alternative path for heap dumps
-# ensure the directory exists and has sufficient space
-#-XX:HeapDumpPath=${heap.dump.path}
-
-## GC logging
-
-#-XX:+PrintGCDetails
-#-XX:+PrintGCTimeStamps
-#-XX:+PrintGCDateStamps
-#-XX:+PrintClassHistogram
-#-XX:+PrintTenuringDistribution
-#-XX:+PrintGCApplicationStoppedTime
-
-# log GC status to a file with time stamps
-# ensure the directory exists
-#-Xloggc:${loggc}
-
-# By default, the GC log file will not rotate.
-# By uncommenting the lines below, the GC log file
-# will be rotated every 128MB at most 32 times.
-#-XX:+UseGCLogFileRotation
-#-XX:NumberOfGCLogFiles=32
-#-XX:GCLogFileSize=128M
-
-# Elasticsearch 5.0.0 will throw an exception on unquoted field names in JSON.
-# If documents were already indexed with unquoted fields in a previous version
-# of Elasticsearch, some operations may throw errors.
-#
-# WARNING: This option will be removed in Elasticsearch 6.0.0 and is provided
-# only for migration purposes.
-#-Delasticsearch.json.allow_unquoted_field_names=true
 
 <% p('elasticsearch.jvm_options').each do |opt| %><%= opt %><% end %>

--- a/jobs/ingestor_syslog/templates/config/jvm.options.erb
+++ b/jobs/ingestor_syslog/templates/config/jvm.options.erb
@@ -1,4 +1,96 @@
-# the default /tmp dir is often noexec, so we need to use one that is not.
+################################################################
+# logstash base config
+# this is the stuff from Elastic. We should update this whenever we update logstash
+################################################################
+## JVM configuration
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+-Xms1g
+-Xmx1g
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
+
+## Locale
+# Set the locale language
+#-Duser.language=en
+
+# Set the locale country
+#-Duser.country=US
+
+# Set the locale variant, if any
+#-Duser.variant=
+
+## basic
+
+# set the I/O temp directory
+#-Djava.io.tmpdir=$HOME
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+#-Djna.nosys=true
+
+# Turn on JRuby invokedynamic
+-Djruby.compile.invokedynamic=true
+# Force Compilation
+-Djruby.jit.threshold=0
+# Make sure joni regexp interruptability is enabled
+-Djruby.regexp.interruptible=true
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps
+# ensure the directory exists and has sufficient space
+#-XX:HeapDumpPath=${LOGSTASH_HOME}/heapdump.hprof
+
+## GC logging
+#-XX:+PrintGCDetails
+#-XX:+PrintGCTimeStamps
+#-XX:+PrintGCDateStamps
+#-XX:+PrintClassHistogram
+#-XX:+PrintTenuringDistribution
+#-XX:+PrintGCApplicationStoppedTime
+
+# log GC status to a file with time stamps
+# ensure the directory exists
+#-Xloggc:${LS_GC_LOG_FILE}
+
+# Entropy source for randomness
+-Djava.security.egd=file:/dev/urandom
+
+# Copy the logging context from parent threads to children
+-Dlog4j2.isThreadContextMapInheritable=true
+
+17-:--add-opens java.base/sun.nio.ch=ALL-UNNAMED
+17-:--add-opens java.base/java.io=ALL-UNNAMED
+################################################################
+# end logstash base config. 
+# everything after this is our customizations
+################################################################
+
 -Djava.io.tmpdir=/var/vcap/sys/tmp/ingestor_syslog
 
 <% p('logstash.jvm_options').each do |opt| %><%= opt %><% end %>

--- a/packages/elasticsearch/packaging
+++ b/packages/elasticsearch/packaging
@@ -1,8 +1,6 @@
 set -e
 
-tar xzf elasticsearch/elasticsearch-7.9.3-linux-x86_64.tar.gz -C $BOSH_INSTALL_TARGET --strip-components 1
-
-chown -R root:vcap "${BOSH_INSTALL_TARGET}/jdk"
+tar xzf elasticsearch/elasticsearch-7.9.3-no-jdk-linux-x86_64.tar.gz -C $BOSH_INSTALL_TARGET --strip-components 1
 
 # For log4j 2.14 or older. Remove after we update Elasticsearch to 7.16.2 or higher. 
 /bin/rm -f "${BOSH_INSTALL_TARGET}/bin/elasticsearch-sql-cli-7.9.3.jar"

--- a/packages/elasticsearch/spec
+++ b/packages/elasticsearch/spec
@@ -1,5 +1,8 @@
 ---
 name: elasticsearch
 
+dependencies:
+  - openjdk-11
+
 files:
-  - elasticsearch/elasticsearch-7.9.3-linux-x86_64.tar.gz
+  - elasticsearch/elasticsearch-7.9.3-no-jdk-linux-x86_64.tar.gz


### PR DESCRIPTION
Using the bundled JDK means we have to update elasticsearch whenever a new java version comes out which.... doesn't work for us

## Changes proposed in this pull request:
- decouple elasticsearch version from JDK version
-
-

## security considerations
this lets us remediate vulnerabilities faster