### PR TITLE
Update logstash to 7.17.5

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -86,10 +86,6 @@ haproxy/pcre-8.40.tar.gz:
   size: 2065161
   object_id: 28786a5b-7b76-45af-578f-af8bd85ef90a
   sha: sha256:1d75ce90ea3f81ee080cdc04e68c9c25a9fb984861a0618be7bbf676b18eda3e
-kibana/kibana-7.9.3-linux-x86_64.tar.gz:
-  size: 295755102
-  object_id: 74b514c5-0669-4b75-71f0-9b1f81240e97
-  sha: sha256:20106e084f717270ce38290d1d3908db7de09b16233688ce0ec41e1d0dffddd6
 kibana/kibana-7.17.5-linux-x86_64.tar.gz:
   size: 263788794
   object_id: b0aef29a-f939-4632-65a3-0de6b26d4d9c

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -74,10 +74,6 @@ curator/vendor/voluptuous-0.11.5-py2.py3-none-any.whl:
   size: 27677
   object_id: 6889d3b8-07e8-4e17-49a0-474405676494
   sha: sha256:303542b3fc07fb52ec3d7a1c614b329cdbee13a9d681935353d8ea56a7bfa9f1
-elasticsearch/elasticsearch-7.9.3-no-jdk-linux-x86_64.tar.gz:
-  size: 162808745
-  object_id: e3856ece-c8a3-4c2b-6097-53a75ee5eeca
-  sha: sha256:2ab0e23277e2fd9365b53af2653e6107ab46db2117390e84ba53385a96f3559f
 elasticsearch/elasticsearch-7.17.5-no-jdk-linux-x86_64.tar.gz:
   size: 167410729
   object_id: de00c51b-5ecf-4c0d-53fd-04c6a6aaf5bc

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -80,6 +80,7 @@ elasticsearch/elasticsearch-7.9.3-no-jdk-linux-x86_64.tar.gz:
   sha: sha256:2ab0e23277e2fd9365b53af2653e6107ab46db2117390e84ba53385a96f3559f
 elasticsearch/elasticsearch-7.17.5-no-jdk-linux-x86_64.tar.gz:
   size: 167410729
+  object_id: de00c51b-5ecf-4c0d-53fd-04c6a6aaf5bc
   sha: sha256:d301e4e270bbb3391e3aa721adc6c4cf86c3dcc5521a914120408d32ac30a92e
 haproxy/haproxy-1.7.5.tar.gz:
   size: 1743979

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -91,9 +91,9 @@ kibana/kibana-7.9.3-linux-x86_64.tar.gz:
   object_id: 74b514c5-0669-4b75-71f0-9b1f81240e97
   sha: sha256:20106e084f717270ce38290d1d3908db7de09b16233688ce0ec41e1d0dffddd6
 logstash/logstash-7.17.5.tar.gz:
-  size: 20115394
-  object_id: 3c16ff46-ba27-49d7-6a7f-4a1d5b93b885
-  sha: sha256:d82626b369049ba68a06482bad83a15cb957ebba5d39aa7eeead55bac47ad86c
+  size: 363609474
+  object_id: 6d8f78c8-3d0a-4517-7026-b4353ebdc05f
+  sha: sha256:ccad67d8528c41f0b20da2eb41d8913650612538714b0da0946062be86a42c6b
 logstash/logstash-filter-alter-3.0.2.zip:
   size: 7425
   object_id: c91d4188-e46c-4de9-70c8-5c087b26e134

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -90,6 +90,10 @@ kibana/kibana-7.9.3-linux-x86_64.tar.gz:
   size: 295755102
   object_id: 74b514c5-0669-4b75-71f0-9b1f81240e97
   sha: sha256:20106e084f717270ce38290d1d3908db7de09b16233688ce0ec41e1d0dffddd6
+kibana/kibana-7.17.5-linux-x86_64.tar.gz:
+  size: 263788794
+  object_id: b0aef29a-f939-4632-65a3-0de6b26d4d9c
+  sha: sha256:3a86dbb377acd407a04c59b31b6967fa2b8969166b38d6a6cc340e5ca445d939
 logstash/logstash-7.17.5.tar.gz:
   size: 363609474
   object_id: 6d8f78c8-3d0a-4517-7026-b4353ebdc05f

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -78,6 +78,9 @@ elasticsearch/elasticsearch-7.9.3-no-jdk-linux-x86_64.tar.gz:
   size: 162808745
   object_id: e3856ece-c8a3-4c2b-6097-53a75ee5eeca
   sha: sha256:2ab0e23277e2fd9365b53af2653e6107ab46db2117390e84ba53385a96f3559f
+elasticsearch/elasticsearch-7.17.5-no-jdk-linux-x86_64.tar.gz:
+  size: 167410729
+  sha: sha256:d301e4e270bbb3391e3aa721adc6c4cf86c3dcc5521a914120408d32ac30a92e
 haproxy/haproxy-1.7.5.tar.gz:
   size: 1743979
   object_id: 4ee72933-de11-4d3c-4657-b6b284388def

--- a/packages/elasticsearch/packaging
+++ b/packages/elasticsearch/packaging
@@ -1,3 +1,3 @@
 set -e
 
-tar xzf elasticsearch/elasticsearch-7.9.3-no-jdk-linux-x86_64.tar.gz -C $BOSH_INSTALL_TARGET --strip-components 1
+tar xzf elasticsearch/elasticsearch-7.17.5-no-jdk-linux-x86_64.tar.gz -C $BOSH_INSTALL_TARGET --strip-components 1

--- a/packages/elasticsearch/packaging
+++ b/packages/elasticsearch/packaging
@@ -1,6 +1,3 @@
 set -e
 
 tar xzf elasticsearch/elasticsearch-7.9.3-no-jdk-linux-x86_64.tar.gz -C $BOSH_INSTALL_TARGET --strip-components 1
-
-# For log4j 2.14 or older. Remove after we update Elasticsearch to 7.16.2 or higher. 
-/bin/rm -f "${BOSH_INSTALL_TARGET}/bin/elasticsearch-sql-cli-7.9.3.jar"

--- a/packages/elasticsearch/spec
+++ b/packages/elasticsearch/spec
@@ -2,7 +2,7 @@
 name: elasticsearch
 
 dependencies:
-- openjdk-11
+  - openjdk-11
 
 files:
-- elasticsearch/elasticsearch-7.17.5-no-jdk-linux-x86_64.tar.gz
+  - elasticsearch/elasticsearch-7.17.5-no-jdk-linux-x86_64.tar.gz

--- a/packages/elasticsearch/spec
+++ b/packages/elasticsearch/spec
@@ -2,9 +2,7 @@
 name: elasticsearch
 
 dependencies:
-
 - openjdk-11
 
 files:
-
 - elasticsearch/elasticsearch-7.17.5-no-jdk-linux-x86_64.tar.gz

--- a/packages/elasticsearch/spec
+++ b/packages/elasticsearch/spec
@@ -2,7 +2,9 @@
 name: elasticsearch
 
 dependencies:
-  - openjdk-11
+
+- openjdk-11
 
 files:
-  - elasticsearch/elasticsearch-7.9.3-no-jdk-linux-x86_64.tar.gz
+
+- elasticsearch/elasticsearch-7.17.5-no-jdk-linux-x86_64.tar.gz

--- a/packages/kibana/packaging
+++ b/packages/kibana/packaging
@@ -1,3 +1,3 @@
 set -e
 
-tar xzf kibana/kibana-7.9.3-linux-x86_64.tar.gz -C $BOSH_INSTALL_TARGET --strip-components 1
+tar xzf kibana/kibana-7.17.5-linux-x86_64.tar.gz -C $BOSH_INSTALL_TARGET --strip-components 1

--- a/packages/kibana/spec
+++ b/packages/kibana/spec
@@ -2,4 +2,4 @@
 name: kibana
 
 files:
-  - kibana/kibana-7.9.3-linux-x86_64.tar.gz
+  - kibana/kibana-7.17.5-linux-x86_64.tar.gz

--- a/packages/logstash/packaging
+++ b/packages/logstash/packaging
@@ -15,6 +15,3 @@ logstash-plugin install "file://${PWD}/logstash/logstash-input-relp-3.0.2.zip"
 logstash-plugin install "file://${PWD}/logstash/logstash-filter-translate-3.0.3.zip"
 logstash-plugin install "file://${PWD}/logstash/logstash-input-syslog-3.2.2.zip"
 logstash-plugin install "file://${PWD}/logstash/logstash-output-syslog-3.0.5.zip"
-
-# Removes JndiLookup Class to address the log4j log4shell vulnerability
-zip -d "${BOSH_INSTALL_TARGET}"/logstash-core/**/*/log4j-core-2.* org/apache/logging/log4j/core/lookup/JndiLookup.class


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update logstash to version 7.17.5 : https://www.elastic.co/downloads/past-releases/logstash-7-17-5
  - Previously the blob had been fetched from https://github.com/elastic/logstash/releases/tag/v7.17.5, which is the source code for Logstash and not the release distribution that we actually want
- Update Kibana to version 7.17.5: https://www.elastic.co/downloads/past-releases/kibana-7-17-5
- Update Elasticsearch No JDK to version 7.17.5: https://www.elastic.co/downloads/past-releases/elasticsearch-no-jdk-7-17-5

## security considerations

Elasticsearch and Logstash updated to versions that are patched for log4j vulnerabilities and we can remove workarounds for vulnerabilities in packaging scripts