### PR TITLE
revert kibana to version 7.9.3

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -86,10 +86,10 @@ haproxy/pcre-8.40.tar.gz:
   size: 2065161
   object_id: 28786a5b-7b76-45af-578f-af8bd85ef90a
   sha: sha256:1d75ce90ea3f81ee080cdc04e68c9c25a9fb984861a0618be7bbf676b18eda3e
-kibana/kibana-7.17.5-linux-x86_64.tar.gz:
-  size: 263788794
-  object_id: b0aef29a-f939-4632-65a3-0de6b26d4d9c
-  sha: sha256:3a86dbb377acd407a04c59b31b6967fa2b8969166b38d6a6cc340e5ca445d939
+kibana/kibana-7.9.3-linux-x86_64.tar.gz:
+  size: 295755102
+  object_id: 74b514c5-0669-4b75-71f0-9b1f81240e97
+  sha: sha256:20106e084f717270ce38290d1d3908db7de09b16233688ce0ec41e1d0dffddd6
 logstash/logstash-7.17.5.tar.gz:
   size: 363609474
   object_id: 6d8f78c8-3d0a-4517-7026-b4353ebdc05f

--- a/packages/kibana/packaging
+++ b/packages/kibana/packaging
@@ -1,3 +1,3 @@
 set -e
 
-tar xzf kibana/kibana-7.17.5-linux-x86_64.tar.gz -C $BOSH_INSTALL_TARGET --strip-components 1
+tar xzf kibana/kibana-7.9.3-linux-x86_64.tar.gz -C $BOSH_INSTALL_TARGET --strip-components 1

--- a/packages/kibana/spec
+++ b/packages/kibana/spec
@@ -2,4 +2,5 @@
 name: kibana
 
 files:
-  - kibana/kibana-7.17.5-linux-x86_64.tar.gz
+
+- kibana/kibana-7.9.3-linux-x86_64.tar.gz


### PR DESCRIPTION
## Changes proposed in this pull request:

- Deploying Kibana 7.17.5 was causing mysterious Bosh deployment errors, so reverting to 7.9.3

## security considerations

None. We were previously running Kibana 7.9.3.
