### PR TITLE
migrate datastore

### DIFF
--- a/jobs/elasticsearch-platform/spec
+++ b/jobs/elasticsearch-platform/spec
@@ -150,3 +150,6 @@ properties:
   elasticsearch.snapshots.repository:
     description: Repository name for automatic snapshots
     default: ''
+  elasticsearch.migrate_data:
+    description: migrate data from /var/vcap/store/elasticsearch to /var/vcap/store/elasticsearch-platform
+    default: false

--- a/jobs/elasticsearch-platform/templates/bin/pre-start
+++ b/jobs/elasticsearch-platform/templates/bin/pre-start
@@ -26,9 +26,16 @@ chown root:vcap /var/vcap/jobs/elasticsearch-platform/config/jvm.options
 log_dir=/var/vcap/packages/elasticsearch-platform/logs
 
 if [[ -d ${log_dir} ]]; then
-  rmdir ${log_dir}
+  # rmdir fails on a symlink
+  rmdir ${log_dir} || rm ${log_dir}
 fi
 
 if [[ ! -a ${log_dir} ]]; then
   ln -s /var/vcap/sys/log/elasticsearch-platform ${log_dir}
 fi
+
+<% if p("elasticsearch.migrate_data") %>
+if [[ -d /var/vcap/store/elasticsearch ]]; then
+    cp -pR /var/vcap/store/elasticsearch/nodes /var/vcap/store/elasticsearch-platform
+fi
+<% end %>

--- a/jobs/elasticsearch-platform/templates/config/config.yml.erb
+++ b/jobs/elasticsearch-platform/templates/config/config.yml.erb
@@ -3,7 +3,7 @@ bootstrap:
 
 path:
   logs: "/var/vcap/sys/log/elasticsearch-platform"
-  data: "/var/vcap/store/elasticsearch"
+  data: "/var/vcap/store/elasticsearch-platform"
 <% if p('elasticsearch.path_repo') != '' %>
   repo: ["<%= p('elasticsearch.path_repo') %>"]
 <% end %>


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add pre-start script to copy data from existing `elasticsearch` persistent disk to `elasticsearch-platform` since we have renamed the job to `elasticsearch-platform`

## security considerations

None
