### PR TITLE
add property to kibana conf for specifying public base URL

### DIFF
--- a/jobs/kibana-platform/spec
+++ b/jobs/kibana-platform/spec
@@ -40,6 +40,8 @@ properties:
   kibana.port:
     description: "Kibana is served by a back end server. This controls which port to use."
     default: 5601
+  kibana.public_base_url:
+    description: "The publicly available URL that end-users access Kibana at (e.g. https://kibana-platform.com)"
   kibana.host:
     description: "This setting specifies the IP address of the back end server."
     default: "0.0.0.0"

--- a/jobs/kibana-platform/templates/config/kibana.conf.erb
+++ b/jobs/kibana-platform/templates/config/kibana.conf.erb
@@ -8,6 +8,9 @@ server.host: <%= p('kibana.host') %>
 # specify that path here. The basePath can't end in a slash.
 # server.basePath: ""
 
+# The publicly available URL that end-users access Kibana at
+server.publicBaseUrl: <%= p('kibana.public_base_url') %>
+
 # The Elasticsearch instance to use for all your queries.
 # elasticsearch.url: "http://localhost:9200"
 <%


### PR DESCRIPTION
## Changes proposed in this pull request:

Add property to kibana conf for specifying public base URL to address this error which is appearing in Kibana

![Screen shot of Kibana UI showing error message that says server.publicBaseUrl configuration is missing](https://user-images.githubusercontent.com/1001694/186237538-b60b9242-2ec1-4a26-a145-32635f629e05.png)

## security considerations

None
