### PR TITLE
update elasticsearch-platform pre-start script 

### DIFF
--- a/jobs/elasticsearch-platform/spec
+++ b/jobs/elasticsearch-platform/spec
@@ -153,3 +153,6 @@ properties:
   elasticsearch.migrate_data:
     description: migrate data from /var/vcap/store/elasticsearch to /var/vcap/store/elasticsearch-platform
     default: false
+  elasticsearch.delete_migrated_data:
+    description: delete /var/vcap/store/elasticsearch
+    default: false

--- a/jobs/elasticsearch-platform/templates/bin/pre-start
+++ b/jobs/elasticsearch-platform/templates/bin/pre-start
@@ -36,6 +36,15 @@ fi
 
 <% if p("elasticsearch.migrate_data") %>
 if [[ -d /var/vcap/store/elasticsearch ]]; then
-    cp -pRu /var/vcap/store/elasticsearch/nodes /var/vcap/store/elasticsearch-platform
+  mkdir /var/vcap/store/elasticsearch-platform || true
+  rsync -au --delete /var/vcap/store/elasticsearch/nodes /var/vcap/store/elasticsearch-platform/nodes
+fi
+<% end %>
+
+<% if p("elasticsearch.delete_migrated_data") %>
+if [[ -d /var/vcap/store/elasticsearch && -d /var/vcap/store/elasticsearch-platform ]]; then
+  if cat /var/vcap/jobs/elasticsearch-platform/config/elasticsearch.yml | grep -q 'data: "/var/vcap/store/elasticsearch-platform"'; then
+    rm -rf /var/vcap/store/elasticsearch
+  fi
 fi
 <% end %>


### PR DESCRIPTION
## Changes proposed in this pull request:

- Use `rsync` instead of `cp` for copying data from data folder for old job name (`elasticsearch`) to new job name (`elasticsearch-platform`)
  - In my testing, `rsync` is significantly faster than `cp`, especially with the `-a` option
  - Running `cp` after `rsync` seems to produce undesirable duplicate files
- Support deleting migrated data from the original job name (`elasticsearch`)

## security considerations

None
