### PR TITLE
remove --delete flag from rsync command to copy data

### DIFF
--- a/jobs/elasticsearch-platform/templates/bin/pre-start
+++ b/jobs/elasticsearch-platform/templates/bin/pre-start
@@ -37,7 +37,7 @@ fi
 <% if p("elasticsearch.migrate_data") %>
 if [[ -d /var/vcap/store/elasticsearch ]]; then
   mkdir /var/vcap/store/elasticsearch-platform || true
-  rsync -au --delete /var/vcap/store/elasticsearch/nodes /var/vcap/store/elasticsearch-platform/nodes
+  rsync -au /var/vcap/store/elasticsearch/nodes /var/vcap/store/elasticsearch-platform/nodes
 fi
 <% end %>
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Remove --delete flag from rsync command to copy data. I don't want to end up in a scenario where Elasticsearch in the VM is now storing and reading data in `elasticsearch-platform`, but deleting data that isn't in `elasticsearch` on startup

## security considerations

None
