### PR TITLE
fix destination for rsync

### DIFF
--- a/jobs/elasticsearch-platform/templates/bin/pre-start
+++ b/jobs/elasticsearch-platform/templates/bin/pre-start
@@ -37,7 +37,7 @@ fi
 <% if p("elasticsearch.migrate_data") %>
 if [[ -d /var/vcap/store/elasticsearch ]]; then
   mkdir /var/vcap/store/elasticsearch-platform || true
-  rsync -au /var/vcap/store/elasticsearch/nodes /var/vcap/store/elasticsearch-platform/nodes
+  rsync -au /var/vcap/store/elasticsearch/nodes /var/vcap/store/elasticsearch-platform
 fi
 <% end %>
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix destination for `rsync` command because files were copied to wrong location

## security considerations

None
