### PR TITLE
Update logs platform to 7.17.8

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -78,10 +78,6 @@ elasticsearch/elasticsearch-7.9.3-no-jdk-linux-x86_64.tar.gz:
   size: 162808745
   object_id: e3856ece-c8a3-4c2b-6097-53a75ee5eeca
   sha: sha256:2ab0e23277e2fd9365b53af2653e6107ab46db2117390e84ba53385a96f3559f
-elasticsearch/elasticsearch-7.17.5-no-jdk-linux-x86_64.tar.gz:
-  size: 167410729
-  object_id: de00c51b-5ecf-4c0d-53fd-04c6a6aaf5bc
-  sha: sha256:d301e4e270bbb3391e3aa721adc6c4cf86c3dcc5521a914120408d32ac30a92e
 elasticsearch/elasticsearch-7.17.8-no-jdk-linux-x86_64.tar.gz:
   size: 167420965
   object_id: 9736ed14-c267-4678-7463-532e8bad9c95
@@ -102,10 +98,6 @@ kibana/kibana-7.17.8-linux-x86_64.tar.gz:
   size: 268709961
   object_id: 70e48428-62ce-4879-5c09-5d3dc5377500
   sha: sha256:1926fd553e2ff1b89e9613ba5d2b96ab0fe485aab0120a613051bc8a1cde7964
-logstash/logstash-7.17.5.tar.gz:
-  size: 363609474
-  object_id: 6d8f78c8-3d0a-4517-7026-b4353ebdc05f
-  sha: sha256:ccad67d8528c41f0b20da2eb41d8913650612538714b0da0946062be86a42c6b
 logstash/logstash-7.17.8-linux-x86_64.tar.gz:
   size: 364452036
   object_id: 47211553-01c9-4156-6cc6-833d70f8d260

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -82,6 +82,9 @@ elasticsearch/elasticsearch-7.17.5-no-jdk-linux-x86_64.tar.gz:
   size: 167410729
   object_id: de00c51b-5ecf-4c0d-53fd-04c6a6aaf5bc
   sha: sha256:d301e4e270bbb3391e3aa721adc6c4cf86c3dcc5521a914120408d32ac30a92e
+elasticsearch/elasticsearch-7.17.8-linux-x86_64.tar.gz:
+  size: 314823457
+  sha: sha256:1c40ba4e0912da1432cb85c0d246f68e14a7da249feea91752c8eaeb28adf0ac
 haproxy/haproxy-1.7.5.tar.gz:
   size: 1743979
   object_id: 4ee72933-de11-4d3c-4657-b6b284388def
@@ -98,6 +101,9 @@ kibana/kibana-7.17.5-linux-x86_64.tar.gz:
   size: 263788794
   object_id: b0aef29a-f939-4632-65a3-0de6b26d4d9c
   sha: sha256:3a86dbb377acd407a04c59b31b6967fa2b8969166b38d6a6cc340e5ca445d939
+kibana/kibana-7.17.8-linux-x86_64.tar.gz:
+  size: 268709961
+  sha: sha256:1926fd553e2ff1b89e9613ba5d2b96ab0fe485aab0120a613051bc8a1cde7964
 logstash/logstash-7.17.5.tar.gz:
   size: 363609474
   object_id: 6d8f78c8-3d0a-4517-7026-b4353ebdc05f

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -82,9 +82,10 @@ elasticsearch/elasticsearch-7.17.5-no-jdk-linux-x86_64.tar.gz:
   size: 167410729
   object_id: de00c51b-5ecf-4c0d-53fd-04c6a6aaf5bc
   sha: sha256:d301e4e270bbb3391e3aa721adc6c4cf86c3dcc5521a914120408d32ac30a92e
-elasticsearch/elasticsearch-7.17.8-linux-x86_64.tar.gz:
-  size: 314823457
-  sha: sha256:1c40ba4e0912da1432cb85c0d246f68e14a7da249feea91752c8eaeb28adf0ac
+elasticsearch/elasticsearch-7.17.8-no-jdk-linux-x86_64.tar.gz:
+  size: 167420965
+  object_id: 9736ed14-c267-4678-7463-532e8bad9c95
+  sha: sha256:7d7e23ad38107842eed2ec57ee5be1cc45f97f2df8e31f71c928af0b199116ec
 haproxy/haproxy-1.7.5.tar.gz:
   size: 1743979
   object_id: 4ee72933-de11-4d3c-4657-b6b284388def
@@ -97,17 +98,18 @@ kibana/kibana-7.9.3-linux-x86_64.tar.gz:
   size: 295755102
   object_id: 74b514c5-0669-4b75-71f0-9b1f81240e97
   sha: sha256:20106e084f717270ce38290d1d3908db7de09b16233688ce0ec41e1d0dffddd6
-kibana/kibana-7.17.5-linux-x86_64.tar.gz:
-  size: 263788794
-  object_id: b0aef29a-f939-4632-65a3-0de6b26d4d9c
-  sha: sha256:3a86dbb377acd407a04c59b31b6967fa2b8969166b38d6a6cc340e5ca445d939
 kibana/kibana-7.17.8-linux-x86_64.tar.gz:
   size: 268709961
+  object_id: 70e48428-62ce-4879-5c09-5d3dc5377500
   sha: sha256:1926fd553e2ff1b89e9613ba5d2b96ab0fe485aab0120a613051bc8a1cde7964
 logstash/logstash-7.17.5.tar.gz:
   size: 363609474
   object_id: 6d8f78c8-3d0a-4517-7026-b4353ebdc05f
   sha: sha256:ccad67d8528c41f0b20da2eb41d8913650612538714b0da0946062be86a42c6b
+logstash/logstash-7.17.8-linux-x86_64.tar.gz:
+  size: 364452036
+  object_id: 47211553-01c9-4156-6cc6-833d70f8d260
+  sha: sha256:f964de7111e6fb04f92469e4d2432aa9a26042ab1490eaae18c80d230233132b
 logstash/logstash-filter-alter-3.0.2.zip:
   size: 7425
   object_id: c91d4188-e46c-4de9-70c8-5c087b26e134

--- a/packages/elasticsearch-platform/packaging
+++ b/packages/elasticsearch-platform/packaging
@@ -1,3 +1,3 @@
 set -e
 
-tar xzf elasticsearch/elasticsearch-7.17.5-no-jdk-linux-x86_64.tar.gz -C $BOSH_INSTALL_TARGET --strip-components 1
+tar xzf elasticsearch/elasticsearch-7.17.8-no-jdk-linux-x86_64.tar.gz -C $BOSH_INSTALL_TARGET --strip-components 1

--- a/packages/elasticsearch-platform/spec
+++ b/packages/elasticsearch-platform/spec
@@ -7,4 +7,4 @@ dependencies:
 
 files:
 
-- elasticsearch/elasticsearch-7.17.5-no-jdk-linux-x86_64.tar.gz
+- elasticsearch/elasticsearch-7.17.8-no-jdk-linux-x86_64.tar.gz

--- a/packages/kibana-platform/packaging
+++ b/packages/kibana-platform/packaging
@@ -1,3 +1,3 @@
 set -e
 
-tar xzf kibana/kibana-7.17.5-linux-x86_64.tar.gz -C $BOSH_INSTALL_TARGET --strip-components 1
+tar xzf kibana/kibana-7.17.8-linux-x86_64.tar.gz -C $BOSH_INSTALL_TARGET --strip-components 1

--- a/packages/kibana-platform/spec
+++ b/packages/kibana-platform/spec
@@ -3,4 +3,4 @@ name: kibana-platform
 
 files:
 
-- kibana/kibana-7.17.5-linux-x86_64.tar.gz
+- kibana/kibana-7.17.8-linux-x86_64.tar.gz

--- a/packages/logstash/packaging
+++ b/packages/logstash/packaging
@@ -5,7 +5,7 @@ set -e -u
 # shellcheck disable=1091
 source /var/vcap/packages/openjdk-11/bosh/compile.env
 
-tar xzf logstash/logstash-7.17.5.tar.gz -C "${BOSH_INSTALL_TARGET}" --strip-components 1
+tar xzf logstash/logstash-7.17.8-linux-x86_64.tar.gz -C "${BOSH_INSTALL_TARGET}" --strip-components 1
 
 export PATH="${BOSH_INSTALL_TARGET}/bin:${PATH}"
 

--- a/packages/logstash/spec
+++ b/packages/logstash/spec
@@ -5,7 +5,7 @@ dependencies:
   - openjdk-11
 
 files:
-  - logstash/logstash-7.17.5.tar.gz
+  - logstash/logstash-7.17.8-linux-x86_64.tar.gz
   - logstash/logstash-filter-alter-3.0.2.zip
   - logstash/logstash-filter-translate-3.0.3.zip
   - logstash/logstash-input-relp-3.0.2.zip


### PR DESCRIPTION
Relates to https://github.com/cloud-gov/private/issues/597

## Changes proposed in this pull request:

- Update Elasticsearch for logs-platform to 7.17.8
- Update Kibana for logs-platform to 7.17.8
- Update Logstash to 7.17.8

## security considerations

None
