### PR TITLE
fix: allow installing dependencies when installing pyyaml

### DIFF
--- a/packages/curator/packaging
+++ b/packages/curator/packaging
@@ -6,5 +6,5 @@ export PATH="/var/vcap/packages/python3/bin:${PATH}" LD_LIBRARY_PATH="/var/vcap/
 # --no-index prevents contacting pypi to download packages
 # --find-links tells pip where to look for the dependancies
 # --prefix installation prefix where lib, bin and other top-level folders are placed
-pip3 install --no-index "--prefix=${BOSH_INSTALL_TARGET}" curator/vendor/PyYAML-3.13.tar.gz
+pip3 install --no-index --find-links ./curator/vendor/ "--prefix=${BOSH_INSTALL_TARGET}" curator/vendor/PyYAML-3.13.tar.gz
 pip3 install --no-index --find-links ./curator/vendor/ "--prefix=${BOSH_INSTALL_TARGET}" curator/elasticsearch-curator-5.8.3.tar.gz


### PR DESCRIPTION
## Changes proposed in this pull request:
- allow installing dependencies when installing pyyaml


## security considerations
None