### PR TITLE
add provides block for curator job spec

### DIFF
--- a/jobs/curator/spec
+++ b/jobs/curator/spec
@@ -13,6 +13,10 @@ templates:
   config/actions.yml.erb: config/actions.yml
   config/config.yml.erb: config/config.yml
 
+provides:
+- name: curator
+  type: curator
+
 properties:
   elasticsearch.snapshots.repository:
     description: Repository name for automatic snapshots


### PR DESCRIPTION
## Changes proposed in this pull request:

- add provides block for curator job spec

## security considerations

None, just allows deployment manifests to reference properties of the curator VM
